### PR TITLE
fix ksp integration by defining all plugins in root build file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    id("com.google.devtools.ksp") version "1.4.30-1.0.0-alpha02"
     id("com.android.application")
     kotlin("android")
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
     kotlin("jvm") version "1.4.30" apply false
+    id("com.android.application") version "4.2.0-beta02" apply false
+    id("com.google.devtools.ksp") version "1.4.30-1.0.0-alpha02" apply false
 }
 
 buildscript {
@@ -9,7 +11,6 @@ buildscript {
     }
     val kotlin_version by extra("1.4.30")
     dependencies {
-        classpath("com.android.tools.build:gradle:4.0.2")
         classpath(kotlin("gradle-plugin", version = kotlin_version))
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
I honestly don't know why this does fix the problem but it works around
the extension not found problem.

I've also updated the AGP version to the version KSP uses