### PR TITLE
Changes to GenecyclerListAdapter that also solves issues #6, #7, #8

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel>
+    <bytecodeTargetLevel target="11">
       <module name="annotations" target="1.7" />
       <module name="processor" target="1.7" />
     </bytecodeTargetLevel>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 
+    implementation ("androidx.annotation:annotation:1.1.0")
+    implementation ("androidx.recyclerview:recyclerview:1.1.0")
+
     implementation(project(":core"))
 //    implementation(project(":processor"))
     ksp(project(":processor"))

--- a/app/src/main/java/com/gillongname/gencycler/adapter/TestAdapter.kt
+++ b/app/src/main/java/com/gillongname/gencycler/adapter/TestAdapter.kt
@@ -1,8 +1,7 @@
-package com.gillongname.gencycler
+package com.gillongname.gencycler.adapter
 
 import com.gillongname.annotations.adapter.Adapter
 import com.gillongname.gencycler.models.Sample
 
 @Adapter(Sample::class)
-class TestAdapter2 {
-}
+class TestAdapter2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") version "1.4.30" apply false
-    id("com.android.application") version "4.2.0-beta02" apply false
+    id("com.android.application") version "7.0.0-alpha06" apply false
     id("com.google.devtools.ksp") version "1.4.30-1.0.0-alpha02" apply false
 }
 

--- a/core/src/main/java/com/gillongname/core/GencyclerListAdapter.kt
+++ b/core/src/main/java/com/gillongname/core/GencyclerListAdapter.kt
@@ -5,9 +5,8 @@ import com.gillongname.annotations.GencyclerModel
 import java.util.*
 import kotlin.collections.ArrayList
 
-
 abstract class GencyclerListAdapter<E : GencyclerModel, VH : RecyclerView.ViewHolder>(
-    val elements: MutableList<E> = ArrayList()
+    private val elements: MutableList<E> = ArrayList()
 ) : RecyclerView.Adapter<VH>(), MutableListOperators<E>, MutableList<E> by elements {
 
     override val size: Int
@@ -146,7 +145,6 @@ abstract class GencyclerListAdapter<E : GencyclerModel, VH : RecyclerView.ViewHo
     /**
      * overrides the getItemCount which is constant that way we don't have to generate it
      * It can be overridden if the user want's to
-     *
      */
     override fun getItemCount(): Int = size
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.8.1-all.zip

--- a/processor/src/main/java/com/gillongname/processor/GencyclerProcessor.kt
+++ b/processor/src/main/java/com/gillongname/processor/GencyclerProcessor.kt
@@ -23,7 +23,7 @@ class GencyclerProcessor : SymbolProcessor {
         log = codeGenerator.createNewFile(Dependencies(false), "", "GencyclerProcessor", "log")
     }
 
-    override fun process(resolver: Resolver) {
+    override fun process(resolver: Resolver): List<KSAnnotated> {
         resolver.getAllFiles().forEach {
             log.appendText(it.fileName)
         }
@@ -34,6 +34,8 @@ class GencyclerProcessor : SymbolProcessor {
         resolver.getSymbolsWithAnnotation(ViewHolder::class.qualifiedName!!).forEach {
             log.appendText(it.toString())
         }
+
+        return emptyList()
     }
 
     override fun finish() {


### PR DESCRIPTION
A much cleaner base adapter, I want the adapter to act exactly like a list so now it will.

It implements `kotlin.collection.MutableList` and use the `elements` to delegate some of the functions that are not important for manipulating the `RecyclerView`